### PR TITLE
fix(oauth): Add Accept: application/json header for token exchange

### DIFF
--- a/packages/core/src/mcp/oauth-provider.ts
+++ b/packages/core/src/mcp/oauth-provider.ts
@@ -370,6 +370,7 @@ export class MCPOAuthProvider {
       method: 'POST',
       headers: {
         'Content-Type': 'application/x-www-form-urlencoded',
+        'Accept': 'application/json',
       },
       body: params.toString(),
     });


### PR DESCRIPTION
## TLDR

Adds `Accept: application/json` header to OAuth token exchange requests in `MCPOAuthProvider`. This is a **workaround** for GitHub OAuth, which appears to deviate from OAuth 2.0/2.1 spec (RFC 6749, Section 5.1) by not always returning JSON without an explicit `Accept` header.

## Dive Deep

According to OAuth 2.0 (RFC 6749, Section 5.1 "Access Token Response"), a successful access token response **MUST** use the `application/json` media type. This implies that an OAuth 2.0 compliant client should expect a JSON response by default, and a compliant server should provide it.

However, observations suggest that GitHub's OAuth token endpoint might not consistently return `application/json` without an explicit `Accept: application/json` header in the request. This behavior, if confirmed, would be a non-compliance with the OAuth 2.0 specification, as the client should not be required to explicitly request the mandated response format.

By adding this header, we are explicitly instructing GitHub's token endpoint to return JSON, thereby mitigating the issue and allowing the Gemini CLI to correctly parse the token response. This is a pragmatic solution to ensure interoperability with GitHub's current implementation.

## Reviewer Test Plan

To fully validate this change, you will need to set up a GitHub OAuth App and configure the Gemini CLI to interact with a GitHub Remote MCP server.

1.  **Set up GitHub OAuth App:**
    *   Go to your GitHub account settings -> Developer settings -> OAuth Apps.
    *   Create a new OAuth App.
    *   Set the "Homepage URL" to `http://localhost:7777`.
    *   Set the "Authorization callback URL" to `http://localhost:7777/oauth/callback`.
    *   Note down the `Client ID` and `Client Secret`. These will be used in the Gemini CLI configuration.

2.  **Configure Gemini CLI for GitHub Remote MCP Server:**
    *   The Gemini CLI connects to MCP servers via its configuration file, typically located at `~/.gemini/settings.json`.
    *   You need to add an entry under the `mcpServers` property in this `settings.json` file. This entry will define how the Gemini CLI interacts with the GitHub Remote MCP Server.

    *   **Example `settings.json` snippet for GitHub Remote MCP Server:**
        ```json
        {
          "mcpServers": {
            "github-remote-mcp": {
              "command": "your-github-remote-mcp-server-executable", // Replace with the actual command to run your GitHub Remote MCP Server
              "args": [], // Add any necessary arguments for your server executable
              "env": {
                "GITHUB_CLIENT_ID": "YOUR_GITHUB_OAUTH_APP_CLIENT_ID", // Replace with your Client ID
                "GITHUB_CLIENT_SECRET": "YOUR_GITHUB_OAUTH_APP_CLIENT_SECRET" // Replace with your Client Secret
              },
              "cwd": "/path/to/your/github-remote-mcp-server", // Replace with the working directory of your server
              "url": "https://api.githubcopilot.com/mcp/" // The base URL for the GitHub Remote MCP Server
            }
          }
        }
        ```
    *   **Important Notes:**
        *   `your-github-remote-mcp-server-executable`: This placeholder needs to be replaced with the actual command that starts your GitHub Remote MCP Server. This could be a local executable, a Docker command, or any other method you use to run the server.
        *   `GITHUB_CLIENT_ID` and `GITHUB_CLIENT_SECRET`: These environment variables are examples of how you might pass your OAuth App credentials to the MCP server. The exact environment variable names or configuration methods will depend on how your specific GitHub Remote MCP Server is designed to receive these.
        *   `url`: This is the base URL of the GitHub Remote MCP Server. The Gemini CLI will use this to discover the OAuth endpoints.
        *   **Security Note:** For production or shared environments, it's highly recommended to manage `GITHUB_CLIENT_SECRET` via environment variables or a secure secrets management system rather than hardcoding it directly in `settings.json`.

3.  **Test Authentication:**
    *   Check out this branch: `git checkout fix/github-oauth-token-exchange`
    *   Build the project: `npm install && npm run build`
    *   Start your configured GitHub Remote MCP Server using the command specified in your `settings.json`.
    *   Attempt to authenticate with GitHub OAuth using the Gemini CLI. The CLI should now use your configured GitHub Remote MCP server.
    *   Verify that the token exchange process completes successfully.
    *   Confirm that a valid access token is obtained and saved.
    *   (Optional) Observe network requests during the token exchange to confirm the `Accept: application/json` header is sent.

## Testing Matrix

|          | 🍏  | 🪟  | 🐧  |
| -------- | --- | --- | --- |
| npm run  | ✅  | ❓  | ❓  |
| npx      | ✅  | ❓  | ❓  |
| Docker   | ❓  | ❓  | ❓  |
| Podman   | ❓  | -   | -   |
| Seatbelt | ❓  | -   | -   |

## Linked issues / bugs

<!-- No linked issues at this time. -->